### PR TITLE
fix: posix-compliant booleans

### DIFF
--- a/vesktop-electron-git/vesktop.sh
+++ b/vesktop-electron-git/vesktop.sh
@@ -3,7 +3,7 @@
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-~/.config}
 
 # Allow users to override command-line options
-if [[ -f $XDG_CONFIG_HOME/vesktop-flags.conf ]]; then
+if [ -f $XDG_CONFIG_HOME/vesktop-flags.conf ]; then
     VESKTOP_USER_FLAGS="$(grep -v '^#' $XDG_CONFIG_HOME/vesktop-flags.conf)"
 fi
 

--- a/vesktop-electron/vesktop.sh
+++ b/vesktop-electron/vesktop.sh
@@ -3,7 +3,7 @@
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-~/.config}
 
 # Allow users to override command-line options
-if [[ -f $XDG_CONFIG_HOME/vesktop-flags.conf ]]; then
+if [ -f $XDG_CONFIG_HOME/vesktop-flags.conf ]; then
     VESKTOP_USER_FLAGS="$(grep -v '^#' $XDG_CONFIG_HOME/vesktop-flags.conf)"
 fi
 

--- a/vesktop-git/vesktop.sh
+++ b/vesktop-git/vesktop.sh
@@ -3,7 +3,7 @@
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-~/.config}
 
 # Allow users to override command-line options
-if [[ -f $XDG_CONFIG_HOME/vesktop-flags.conf ]]; then
+if [ -f $XDG_CONFIG_HOME/vesktop-flags.conf ]; then
     VESKTOP_USER_FLAGS="$(grep -v '^#' $XDG_CONFIG_HOME/vesktop-flags.conf)"
 fi
 

--- a/vesktop/vesktop.sh
+++ b/vesktop/vesktop.sh
@@ -3,7 +3,7 @@
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-~/.config}
 
 # Allow users to override command-line options
-if [[ -f $XDG_CONFIG_HOME/vesktop-flags.conf ]]; then
+if [ -f $XDG_CONFIG_HOME/vesktop-flags.conf ]; then
     VESKTOP_USER_FLAGS="$(grep -v '^#' $XDG_CONFIG_HOME/vesktop-flags.conf)"
 fi
 


### PR DESCRIPTION
`[[` is a bashism and $!/bin/sh is specified at the top of each script