### PR TITLE
update to 1.6.3

### DIFF
--- a/vesktop-electron-git/.SRCINFO
+++ b/vesktop-electron-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = vesktop-electron-git
 	pkgdesc = An Electron-based Discord app with Vencord & improved Linux support using system provided Electron. Unsupported
-	pkgver = 1.5.8.r6.g0d9ca22
+	pkgver = 1.6.3.r0.g0f509b0
 	pkgrel = 1
 	url = https://github.com/Vencord/Vesktop
 	arch = x86_64

--- a/vesktop-electron-git/PKGBUILD
+++ b/vesktop-electron-git/PKGBUILD
@@ -3,7 +3,7 @@
 _pkgname=vesktop
 pkgname=vesktop-electron-git
 pkgdesc="An Electron-based Discord app with Vencord & improved Linux support using system provided Electron. Unsupported"
-pkgver=1.5.8.r6.g0d9ca22
+pkgver=1.6.3.r0.g0f509b0
 pkgrel=1
 
 arch=("x86_64" "aarch64")

--- a/vesktop-electron/.SRCINFO
+++ b/vesktop-electron/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = vesktop-electron
 	pkgdesc = An Electron-based Discord app with Vencord & improved Linux support using system provided electron. Unsupported
-	pkgver = 1.6.0
-	pkgrel = 2
+	pkgver = 1.6.3
+	pkgrel = 1
 	url = https://github.com/Vencord/Vesktop
 	arch = x86_64
 	arch = aarch64
@@ -13,10 +13,10 @@ pkgbase = vesktop-electron
 	optdepends = xdg-utils: Open links, files, etc
 	provides = vesktop
 	conflicts = vesktop
-	source = vesktop-1.6.0.tar.gz::https://github.com/Vencord/Vesktop/archive/v1.6.0.tar.gz
+	source = vesktop-1.6.3.tar.gz::https://github.com/Vencord/Vesktop/archive/v1.6.3.tar.gz
 	source = vesktop.desktop
 	source = vesktop.sh
-	sha256sums = 679ea8afaac6fa99d19bc64e0209fb10c0ec70c6b5f887fadd07ca56ec643787
+	sha256sums = 19f131dcfaa48df02268bbda538389c7e1ce63c80420fa617089a83253dba702
 	sha256sums = 455c00b862aa0a7e18ca8e23d65d5c5ee4506cdfb15f1bf6f622cce39827de46
 	sha256sums = a2da313031cfaa892f0f2e51fd0ffafbc14001d4efb0523bb8bfaeb7f4ddc3fa
 

--- a/vesktop-electron/PKGBUILD
+++ b/vesktop-electron/PKGBUILD
@@ -3,8 +3,8 @@
 _pkgname=vesktop
 pkgname=vesktop-electron
 pkgdesc="An Electron-based Discord app with Vencord & improved Linux support using system provided electron. Unsupported"
-pkgver=1.6.0
-pkgrel=2
+pkgver=1.6.3
+pkgrel=1
 
 arch=("x86_64" "aarch64")
 url="https://github.com/Vencord/Vesktop"
@@ -22,9 +22,13 @@ conflicts=('vesktop')
 
 source=("$_pkgname-$pkgver.tar.gz::https://github.com/Vencord/Vesktop/archive/v${pkgver}.tar.gz" "vesktop.desktop" "vesktop.sh")
 
-sha256sums=('679ea8afaac6fa99d19bc64e0209fb10c0ec70c6b5f887fadd07ca56ec643787'
+sha256sums=('19f131dcfaa48df02268bbda538389c7e1ce63c80420fa617089a83253dba702'
             '455c00b862aa0a7e18ca8e23d65d5c5ee4506cdfb15f1bf6f622cce39827de46'
             'a2da313031cfaa892f0f2e51fd0ffafbc14001d4efb0523bb8bfaeb7f4ddc3fa')
+
+prepare() {
+  mv "$srcdir/Vesktop-$pkgver" "$srcdir/$_pkgname-$pkgver"
+}
 
 build() {
   cd "$srcdir/$_pkgname-$pkgver"

--- a/vesktop-git/.SRCINFO
+++ b/vesktop-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = vesktop-git
 	pkgdesc = A standalone Electron-based Discord app with Vencord & improved Linux support
-	pkgver = 1.5.8.r6.g0d9ca22
+	pkgver = 1.6.3.r0.g0f509b0
 	pkgrel = 1
 	url = https://github.com/Vencord/Vesktop
 	arch = x86_64
@@ -20,7 +20,7 @@ pkgbase = vesktop-git
 	source = vesktop.desktop
 	source = vesktop.sh
 	sha256sums = SKIP
-	sha256sums = 455c00b862aa0a7e18ca8e23d65d5c5ee4506cdfb15f1bf6f622cce39827de46
+	sha256sums = 98fa8f661b065c2d825e24f0055a40ae01d58d23628ad7ebf6914296209dd43c
 	sha256sums = 506c246328af639d6f6a3e52215c7b34af2a6df11d195de6f57a8bbee750cce9
 
 pkgname = vesktop-git

--- a/vesktop-git/PKGBUILD
+++ b/vesktop-git/PKGBUILD
@@ -3,7 +3,7 @@
 _pkgname=vesktop
 pkgname=vesktop-git
 pkgdesc="A standalone Electron-based Discord app with Vencord & improved Linux support"
-pkgver=1.5.8.r6.g0d9ca22
+pkgver=1.6.3.r0.g0f509b0
 pkgrel=1
 
 arch=("x86_64" "aarch64")
@@ -23,7 +23,7 @@ conflicts=('vesktop')
 source=("$_pkgname::git+$url.git" "vesktop.desktop" "vesktop.sh")
 
 sha256sums=('SKIP'
-            '455c00b862aa0a7e18ca8e23d65d5c5ee4506cdfb15f1bf6f622cce39827de46'
+            '98fa8f661b065c2d825e24f0055a40ae01d58d23628ad7ebf6914296209dd43c'
             '506c246328af639d6f6a3e52215c7b34af2a6df11d195de6f57a8bbee750cce9')
 
 pkgver() {

--- a/vesktop-git/vesktop.desktop
+++ b/vesktop-git/vesktop.desktop
@@ -9,4 +9,4 @@ GenericName=Internet Messenger
 Categories=Network;
 Keywords=discord;vencord;electron;chat;
 Comment=Vesktop is a custom Discord App aiming to give you better performance and improve linux support. Vencord comes pre-installed
-MimeType=x-scheme-handler/discord;
+MimeType=x-scheme-handler/discord

--- a/vesktop/.SRCINFO
+++ b/vesktop/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = vesktop
 	pkgdesc = A standalone Electron-based Discord app with Vencord & improved Linux support
-	pkgver = 1.6.0
+	pkgver = 1.6.3
 	pkgrel = 1
 	url = https://github.com/Vencord/Vesktop
 	arch = x86_64
@@ -13,10 +13,10 @@ pkgbase = vesktop
 	depends = nss
 	optdepends = libnotify: Notifications
 	optdepends = xdg-utils: Open links, files, etc
-	source = vesktop-1.6.0.tar.gz::https://github.com/Vencord/Vesktop/archive/v1.6.0.tar.gz
+	source = vesktop-1.6.3.tar.gz::https://github.com/Vencord/Vesktop/archive/v1.6.3.tar.gz
 	source = vesktop.desktop
 	source = vesktop.sh
-	sha256sums = 679ea8afaac6fa99d19bc64e0209fb10c0ec70c6b5f887fadd07ca56ec643787
+	sha256sums = 19f131dcfaa48df02268bbda538389c7e1ce63c80420fa617089a83253dba702
 	sha256sums = 98fa8f661b065c2d825e24f0055a40ae01d58d23628ad7ebf6914296209dd43c
 	sha256sums = 506c246328af639d6f6a3e52215c7b34af2a6df11d195de6f57a8bbee750cce9
 

--- a/vesktop/PKGBUILD
+++ b/vesktop/PKGBUILD
@@ -3,7 +3,7 @@
 _pkgname=vesktop
 pkgname=vesktop
 pkgdesc="A standalone Electron-based Discord app with Vencord & improved Linux support"
-pkgver=1.6.0
+pkgver=1.6.3
 pkgrel=1
 
 arch=("x86_64" "aarch64")
@@ -19,9 +19,13 @@ optdepends=(
 
 source=("$_pkgname-$pkgver.tar.gz::https://github.com/Vencord/Vesktop/archive/v${pkgver}.tar.gz" "vesktop.desktop" "vesktop.sh")
 
-sha256sums=('679ea8afaac6fa99d19bc64e0209fb10c0ec70c6b5f887fadd07ca56ec643787'
+sha256sums=('19f131dcfaa48df02268bbda538389c7e1ce63c80420fa617089a83253dba702'
             '98fa8f661b065c2d825e24f0055a40ae01d58d23628ad7ebf6914296209dd43c'
             '506c246328af639d6f6a3e52215c7b34af2a6df11d195de6f57a8bbee750cce9')
+
+prepare() {
+  mv "$srcdir/Vesktop-$pkgver" "$srcdir/$_pkgname-$pkgver"
+}
 
 build() {
   cd "$srcdir/$_pkgname-$pkgver"


### PR DESCRIPTION
Also adds prepare() to non-git packages to rename extracted directory from Vesktop-* to vesktop-* (GitHub archives use repo name casing) 